### PR TITLE
ext: app.cli support

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,25 +31,24 @@ The Flask-CLI package is on PyPI so all you need is:
 Usage
 =====
 
-Use this library as fallback when importing from ``flask.cli``.
+Initialize the extension like this:
 
 .. code-block:: python
 
-   try:
-       from flask.cli import FlaskGroup
-   except ImportError
-       from flask_cli.cli import FlaskGroup
+   from flask import Flask
+   from flask_cli import FlaskCLI
+   app = Flask('myapp')
+   FlaskCLI(app)
 
-Note Flask-CLI is only a backport of ``flask.cli``. Most noteably, there's no integration into the Flask application object. E.g. the following won't work:
+   @app.cli.command()
+   def mycmd():
+       click.echo("Test")
+
+Import from this library instead of ``flask.cli``:
 
 .. code-block:: python
 
-    app = Flask(__name__)
-
-    @app.cli.command()
-    def initdb():
-        """Initialize the database."""
-        print 'Init the db'
+   from flask_cli import FlaskGroup
 
 .. include:: ../CHANGES
 

--- a/flask_cli/__init__.py
+++ b/flask_cli/__init__.py
@@ -7,7 +7,7 @@
 # modify it under the terms of the Revised BSD License; see LICENSE
 # file for more details.
 
-"""Flask-CLI is a partial backport of Flask 1.0 new click integration to v0.10.
+"""Flask-CLI is a backport of Flask 1.0 new click integration to v0.10.
 
 Do not install this package if you use Flask 1.0+.
 
@@ -15,8 +15,31 @@ Full documentation of Flask's new click command line integration can be found
 at: http://flask.pocoo.org/docs/dev/cli/.
 """
 
-from __future__ import absolute_import, unicode_literals, print_function
+from __future__ import absolute_import, print_function, unicode_literals
 
+try:
+    from flask.cli import AppGroup, DispatchingApp, FlaskGroup, \
+        NoAppException, ScriptInfo, app_option, cli, debug_option, \
+        find_best_app, locate_app, main, pass_script_info, \
+        prepare_exec_for_file, run_command, script_info_option, \
+        set_app_value, set_debug_value, shell_command, with_appcontext
+except ImportError:
+    from flask_cli.cli import AppGroup, DispatchingApp, FlaskGroup, \
+        NoAppException, ScriptInfo, app_option, cli, debug_option, \
+        find_best_app, locate_app, main, pass_script_info, \
+        prepare_exec_for_file, run_command, script_info_option, \
+        set_app_value, set_debug_value, shell_command, with_appcontext
+
+from .ext import FlaskCLI
 from .version import __version__
 
-__all__ = ('__version__', )
+__all__ = (
+    '__version__', 'FlaskCLI', 'AppGroup', 'DispatchingApp', 'FlaskGroup',
+    'NoAppException', 'ScriptInfo', 'app_option', 'cli', 'debug_option',
+    'find_best_app', 'locate_app', 'main', 'pass_script_info',
+    'prepare_exec_for_file', 'run_command', 'script_info_option',
+    'set_app_value', 'set_debug_value', 'shell_command', 'with_appcontext',
+)
+
+if __name__ == '__main__':
+    main(as_module=True)

--- a/flask_cli/ext.py
+++ b/flask_cli/ext.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Flask-CLI
+# Copyright (C) 2015 CERN.
+#
+# Flask-AppFactory is free software; you can redistribute it and/or
+# modify it under the terms of the Revised BSD License; see LICENSE
+# file for more details.
+
+"""Flask extension to enable CLI."""
+
+from . import AppGroup
+
+
+class FlaskCLI(object):
+
+    """Flask-CLI extension.
+
+    Initialization of the extension:
+
+    >>> from flask import Flask
+    >>> from flask_cli import FlaskCLI
+    >>> app = Flask('myapp')
+    >>> FlaskCLI(app)
+
+    or alternatively using the factory pattern:
+
+    >>> app = Flask('myapp')
+    >>> ext = FlaskCLI()
+    >>> ext.init_app(app)
+    """
+
+    def __init__(self, app=None):
+        """Initialize the Flask-CLI."""
+        if app is not None:
+            self.init_app(app)
+
+    def init_app(self, app):
+        """Initialize a Flask application."""
+        # Follow the Flask guidelines on usage of app.extensions
+        if not hasattr(app, 'extensions'):
+            app.extensions = {}
+        if 'flask-cli' in app.extensions:
+            raise RuntimeError("Flask-CLI application already initialized")
+        app.extensions['flask-cli'] = self
+
+        if not hasattr(app, 'cli'):
+            app.cli = AppGroup(app)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -126,6 +126,3 @@ def test_flaskgroup():
     result = runner.invoke(cli, ['test'])
     assert result.exit_code == 0
     assert result.output == 'flaskgroup\n'
-
-
-

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Flask-CLI
+# Copyright (C) 2015 CERN.
+#
+# Flask-AppFactory is free software; you can redistribute it and/or
+# modify it under the terms of the Revised BSD License; see LICENSE
+# file for more details.
+
+"""Tests for extension."""
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+import click
+import pytest
+from click.testing import CliRunner
+from flask import Flask, current_app
+from flask_cli import FlaskCLI, ScriptInfo
+
+
+def test_ext_init():
+    """Test of find_best_app."""
+    app = Flask('exttest')
+    FlaskCLI(app)
+    assert isinstance(app.cli, click.Group)
+
+    app = Flask('exttest')
+    ext = FlaskCLI()
+    ext.init_app(app)
+    assert isinstance(app.cli, click.Group)
+    pytest.raises(RuntimeError, ext.init_app, app)
+
+
+def test_ext_cmd():
+    """Test creating commands."""
+    app = Flask('exttest')
+    FlaskCLI(app)
+
+    @app.cli.command()
+    def test1():
+        click.echo("TEST")
+
+    @app.cli.command(with_appcontext=True)
+    def test2():
+        click.echo(current_app.name)
+
+    obj = ScriptInfo(create_app=lambda info: app)
+    runner = CliRunner()
+    result = runner.invoke(test1, obj=obj)
+    assert result.exit_code == 0
+    assert result.output == 'TEST\n'
+
+    obj = ScriptInfo(create_app=lambda info: app)
+    runner = CliRunner()
+    result = runner.invoke(test2, obj=obj)
+    assert result.exit_code == 0
+    assert result.output == 'exttest\n'


### PR DESCRIPTION
- Adds FlaskCLI extension to support app.cli.

Signed-off-by: Lars Holm Nielsen lars.holm.nielsen@cern.ch
