### PR TITLE
Updates from Flask 0.11, fixes #15

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,6 +45,40 @@ Initialize the extension like this:
    def mycmd():
        click.echo("Test")
 
+CLI Plugins
+-----------
+
+Flask extensions can always patch the `Flask.cli` instance with more
+commands if they want.  However there is a second way to add CLI plugins
+to Flask which is through `setuptools`.  If you make a Python package that
+should export a Flask command line plugin you can ship a `setup.py` file
+that declares an entrypoint that points to a click command:
+
+Example `setup.py`::
+
+    from setuptools import setup
+
+    setup(
+        name='flask-my-extension',
+        ...
+        entry_points='''
+            [flask.commands]
+            my-command=mypackage.commands:cli
+        ''',
+    )
+
+Inside `mypackage/comamnds.py` you can then export a Click object::
+
+    import click
+
+    @click.command()
+    def cli():
+        """This is an example command."""
+
+Once that package is installed in the same virtualenv as Flask itself you
+can run ``flask my-command`` to invoke your command.  This is useful to
+provide extra functionality that Flask itself cannot ship.
+
 Import from this library instead of ``flask.cli``, e.g.:
 
 .. code-block:: python

--- a/flask_cli/__init__.py
+++ b/flask_cli/__init__.py
@@ -19,26 +19,27 @@ from __future__ import absolute_import, print_function
 
 try:
     from flask.cli import AppGroup, DispatchingApp, FlaskGroup, \
-        NoAppException, ScriptInfo, app_option, cli, debug_option, \
+        NoAppException, ScriptInfo, cli, \
         find_best_app, locate_app, main, pass_script_info, \
-        prepare_exec_for_file, run_command, script_info_option, \
-        set_app_value, set_debug_value, shell_command, with_appcontext
+        prepare_exec_for_file, run_command, \
+        shell_command, with_appcontext
 except ImportError:
     from flask_cli.cli import AppGroup, DispatchingApp, FlaskGroup, \
-        NoAppException, ScriptInfo, app_option, cli, debug_option, \
+        NoAppException, ScriptInfo, cli, \
         find_best_app, locate_app, main, pass_script_info, \
-        prepare_exec_for_file, run_command, script_info_option, \
-        set_app_value, set_debug_value, shell_command, with_appcontext
+        prepare_exec_for_file, run_command, \
+        shell_command, with_appcontext
 
 from .ext import FlaskCLI
+from .helpers import get_debug_flag
 from .version import __version__
 
 __all__ = (
     '__version__', 'FlaskCLI', 'AppGroup', 'DispatchingApp', 'FlaskGroup',
-    'NoAppException', 'ScriptInfo', 'app_option', 'cli', 'debug_option',
+    'NoAppException', 'ScriptInfo', 'cli', 'get_debug_flag',
     'find_best_app', 'locate_app', 'main', 'pass_script_info',
-    'prepare_exec_for_file', 'run_command', 'script_info_option',
-    'set_app_value', 'set_debug_value', 'shell_command', 'with_appcontext',
+    'prepare_exec_for_file', 'run_command',
+    'shell_command', 'with_appcontext',
 )
 
 if __name__ == '__main__':

--- a/flask_cli/cli.py
+++ b/flask_cli/cli.py
@@ -165,7 +165,10 @@ class DispatchingApp(object):
 class ScriptInfo(object):
     """Help object to deal with Flask applications.  This is usually not
     necessary to interface with as it's used internally in the dispatching
-    to click.
+    to click.  In future versions of Flask this object will most likely play
+    a bigger role.  Typically it's created automatically by the
+    :class:`FlaskGroup` but you can also manually create it and pass it
+    onwards as click object.
     """
     def __init__(self, app_import_path=None, create_app=None):
         if create_app is None:
@@ -173,7 +176,10 @@ class ScriptInfo(object):
                 app_import_path = find_default_import_path()
             self.app_import_path = app_import_path
         else:
-            self.app_import_path = None
+            app_import_path = None
+
+        #: Optionally the import path for the Flask application.
+        self.app_import_path = app_import_path
         #: Optionally a function that is passed the script info to create
         #: the instance of the application.
         self.create_app = create_app
@@ -193,10 +199,12 @@ class ScriptInfo(object):
         if self.create_app is not None:
             rv = self.create_app(self)
         else:
-            if self.app_import_path is None:
-                raise NoAppException('Could not locate Flask application. '
-                                     'You did not provide the FLASK_APP '
-                                     'environment variable.')
+            if not self.app_import_path:
+                raise NoAppException(
+                    'Could not locate Flask application. You did not provide '
+                    'the FLASK_APP environment variable.\n\nFor more '
+                    'information see '
+                    'http://flask.pocoo.org/docs/latest/quickstart/')
             rv = locate_app(self.app_import_path)
         debug = get_debug_flag()
         if debug is not None:
@@ -368,6 +376,8 @@ def run_command(info, host, port, reload, debugger, eager_loading,
         # we won't print anything.
         if info.app_import_path is not None:
             print(' * Serving Flask app "%s"' % info.app_import_path)
+        if debug is not None:
+            print(' * Forcing debug mode %s' % (debug and 'on' or 'off'))
 
     run_simple(host, port, app, use_reloader=reload,
                use_debugger=debugger, threaded=with_threads)

--- a/flask_cli/cli.py
+++ b/flask_cli/cli.py
@@ -17,6 +17,7 @@ from threading import Lock, Thread
 import click
 
 from ._compat import iteritems, reraise
+from .helpers import get_debug_flag
 
 
 class NoAppException(click.UsageError):
@@ -98,6 +99,15 @@ def locate_app(app_id):
     return app
 
 
+def find_default_import_path():
+    app = os.environ.get('FLASK_APP')
+    if app is None:
+        return
+    if os.path.isfile(app):
+        return prepare_exec_for_file(app)
+    return app
+
+
 class DispatchingApp(object):
     """Special application that dispatches to a flask application which
     is imported by name in a background thread.  If an error happens
@@ -157,13 +167,13 @@ class ScriptInfo(object):
     necessary to interface with as it's used internally in the dispatching
     to click.
     """
-
-    def __init__(self, app_import_path=None, debug=None, create_app=None):
-        #: The application import path
-        self.app_import_path = app_import_path
-        #: The debug flag.  If this is not None, the application will
-        #: automatically have it's debug flag overridden with this value.
-        self.debug = debug
+    def __init__(self, app_import_path=None, create_app=None):
+        if create_app is None:
+            if app_import_path is None:
+                app_import_path = find_default_import_path()
+            self.app_import_path = app_import_path
+        else:
+            self.app_import_path = None
         #: Optionally a function that is passed the script info to create
         #: the instance of the application.
         self.create_app = create_app
@@ -185,11 +195,12 @@ class ScriptInfo(object):
         else:
             if self.app_import_path is None:
                 raise NoAppException('Could not locate Flask application. '
-                                     'You did not provide FLASK_APP or the '
-                                     '--app parameter.')
+                                     'You did not provide the FLASK_APP '
+                                     'environment variable.')
             rv = locate_app(self.app_import_path)
-        if self.debug is not None:
-            rv.debug = self.debug
+        debug = get_debug_flag()
+        if debug is not None:
+            rv.debug = debug
         self._loaded_app = rv
         return rv
 
@@ -208,29 +219,6 @@ def with_appcontext(f):
         with __ctx.ensure_object(ScriptInfo).load_app().app_context():
             return __ctx.invoke(f, *args, **kwargs)
     return update_wrapper(decorator, f)
-
-
-def set_debug_value(ctx, param, value):
-    ctx.ensure_object(ScriptInfo).debug = value
-
-
-def set_app_value(ctx, param, value):
-    if value is not None:
-        if os.path.isfile(value):
-            value = prepare_exec_for_file(value)
-        elif '.' not in sys.path:
-            sys.path.insert(0, '.')
-    ctx.ensure_object(ScriptInfo).app_import_path = value
-
-
-debug_option = click.Option(['--debug/--no-debug'],
-    help='Enable or disable debug mode.',
-    default=None, callback=set_debug_value)
-
-
-app_option = click.Option(['-a', '--app'],
-    help='The application to run',
-    callback=set_app_value, is_eager=True)
 
 
 class AppGroup(click.Group):
@@ -273,25 +261,12 @@ class FlaskGroup(AppGroup):
 
     :param add_default_commands: if this is True then the default run and
                                  shell commands wil be added.
-    :param add_app_option: adds the default :option:`--app` option.  This gets
-                           automatically disabled if a `create_app`
-                           callback is defined.
-    :param add_debug_option: adds the default :option:`--debug` option.
     :param create_app: an optional callback that is passed the script info
                        and returns the loaded app.
     """
 
-    def __init__(self, add_default_commands=True, add_app_option=None,
-                 add_debug_option=True, create_app=None, **extra):
-        params = list(extra.pop('params', None) or ())
-        if add_app_option is None:
-            add_app_option = create_app is None
-        if add_app_option:
-            params.append(app_option)
-        if add_debug_option:
-            params.append(debug_option)
-
-        AppGroup.__init__(self, params=params, **extra)
+    def __init__(self, add_default_commands=True, create_app=None, **extra):
+        AppGroup.__init__(self, **extra)
         self.create_app = create_app
 
         if add_default_commands:
@@ -342,33 +317,6 @@ class FlaskGroup(AppGroup):
         return AppGroup.main(self, *args, **kwargs)
 
 
-def script_info_option(*args, **kwargs):
-    """This decorator works exactly like :func:`click.option` but is eager
-    by default and stores the value in the :attr:`ScriptInfo.data`.  This
-    is useful to further customize an application factory in very complex
-    situations.
-
-    :param script_info_key: this is a mandatory keyword argument which
-                            defines under which data key the value should
-                            be stored.
-    """
-    try:
-        key = kwargs.pop('script_info_key')
-    except LookupError:
-        raise TypeError('script_info_key not provided.')
-
-    real_callback = kwargs.get('callback')
-    def callback(ctx, param, value):
-        if real_callback is not None:
-            value = real_callback(ctx, value)
-        ctx.ensure_object(ScriptInfo).data[key] = value
-        return value
-
-    kwargs['callback'] = callback
-    kwargs.setdefault('is_eager', True)
-    return click.option(*args, **kwargs)
-
-
 @click.command('run', short_help='Runs a development server.')
 @click.option('--host', '-h', default='127.0.0.1',
               help='The interface to bind to.')
@@ -400,10 +348,12 @@ def run_command(info, host, port, reload, debugger, eager_loading,
     Flask is enabled and disabled otherwise.
     """
     from werkzeug.serving import run_simple
+
+    debug = get_debug_flag()
     if reload is None:
-        reload = info.debug
+        reload = bool(debug)
     if debugger is None:
-        debugger = info.debug
+        debugger = bool(debug)
     if eager_loading is None:
         eager_loading = not reload
 
@@ -418,12 +368,9 @@ def run_command(info, host, port, reload, debugger, eager_loading,
         # we won't print anything.
         if info.app_import_path is not None:
             print(' * Serving Flask app "%s"' % info.app_import_path)
-        if info.debug is not None:
-            print(' * Forcing debug %s' % (info.debug and 'on' or 'off'))
 
     run_simple(host, port, app, use_reloader=reload,
-               use_debugger=debugger, threaded=with_threads,
-               passthrough_errors=True)
+               use_debugger=debugger, threaded=with_threads)
 
 
 @click.command('shell', short_help='Runs a shell in the app context.')
@@ -464,15 +411,21 @@ cli = FlaskGroup(help="""\
 This shell command acts as general utility script for Flask applications.
 
 It loads the application configured (either through the FLASK_APP environment
-variable or the --app parameter) and then provides commands either provided
-by the application or Flask itself.
+variable) and then provides commands either provided by the application or
+Flask itself.
 
 The most useful commands are the "run" and "shell" command.
 
 Example usage:
 
-  flask --app=hello --debug run
-""")
+\b
+  %(prefix)s%(cmd)s FLASK_APP=hello
+  %(prefix)s%(cmd)s FLASK_DEBUG=1
+  %(prefix)sflask run
+""" % {
+    'cmd': os.name == 'posix' and 'export' or 'set',
+    'prefix': os.name == 'posix' and '$ ' or '',
+})
 
 
 def main(as_module=False):

--- a/flask_cli/cli.py
+++ b/flask_cli/cli.py
@@ -56,10 +56,10 @@ def prepare_exec_for_file(filename):
     module = []
 
     # Chop off file extensions or package markers
-    if filename.endswith('.py'):
-        filename = filename[:-3]
-    elif os.path.split(filename)[1] == '__init__.py':
+    if os.path.split(filename)[1] == '__init__.py':
         filename = os.path.dirname(filename)
+    elif filename.endswith('.py'):
+        filename = filename[:-3]
     else:
         raise NoAppException('The file provided (%s) does exist but is not a '
                              'valid Python file.  This means that it cannot '

--- a/flask_cli/cli.py
+++ b/flask_cli/cli.py
@@ -448,7 +448,7 @@ The most useful commands are the "run" and "shell" command.
 Example usage:
 
 \b
-  %(prefix)s%(cmd)s FLASK_APP=hello
+  %(prefix)s%(cmd)s FLASK_APP=hello.py
   %(prefix)s%(cmd)s FLASK_DEBUG=1
   %(prefix)sflask run
 """ % {

--- a/flask_cli/cli.py
+++ b/flask_cli/cli.py
@@ -281,7 +281,24 @@ class FlaskGroup(AppGroup):
             self.add_command(run_command)
             self.add_command(shell_command)
 
+        self._loaded_plugin_commands = False
+
+    def _load_plugin_commands(self):
+        if self._loaded_plugin_commands:
+            return
+        try:
+            import pkg_resources
+        except ImportError:
+            self._loaded_plugin_commands = True
+            return
+
+        for ep in pkg_resources.iter_entry_points('flask.commands'):
+            self.add_command(ep.load(), ep.name)
+        self._loaded_plugin_commands = True
+
     def get_command(self, ctx, name):
+        self._load_plugin_commands()
+
         # We load built-in commands first as these should always be the
         # same no matter what the app does.  If the app does want to
         # override this it needs to make a custom instance of this group
@@ -302,6 +319,8 @@ class FlaskGroup(AppGroup):
             pass
 
     def list_commands(self, ctx):
+        self._load_plugin_commands()
+
         # The commands available is the list of both the application (if
         # available) plus the builtin commands.
         rv = set(click.Group.list_commands(self, ctx))

--- a/flask_cli/cli.py
+++ b/flask_cli/cli.py
@@ -15,6 +15,7 @@ from functools import update_wrapper
 from threading import Lock, Thread
 
 import click
+from flask import __version__ as __flask_version__
 
 from ._compat import iteritems, reraise
 from .helpers import get_debug_flag
@@ -106,6 +107,23 @@ def find_default_import_path():
     if os.path.isfile(app):
         return prepare_exec_for_file(app)
     return app
+
+
+def get_version(ctx, param, value):
+    if not value or ctx.resilient_parsing:
+        return
+    message = 'Flask %(version)s\nPython %(python_version)s'
+    click.echo(message % {
+        'version': __flask_version__,
+        'python_version': sys.version,
+    }, color=ctx.color)
+    ctx.exit()
+
+version_option = click.Option(['--version'],
+                              help='Show the flask version',
+                              expose_value=False,
+                              callback=get_version,
+                              is_flag=True, is_eager=True)
 
 
 class DispatchingApp(object):
@@ -269,12 +287,19 @@ class FlaskGroup(AppGroup):
 
     :param add_default_commands: if this is True then the default run and
                                  shell commands wil be added.
+    :param add_version_option: adds the :option:`--version` option.
     :param create_app: an optional callback that is passed the script info
                        and returns the loaded app.
     """
 
-    def __init__(self, add_default_commands=True, create_app=None, **extra):
-        AppGroup.__init__(self, **extra)
+    def __init__(self, add_default_commands=True, create_app=None,
+                 add_version_option=True, **extra):
+        params = list(extra.pop('params', None) or ())
+
+        if add_version_option:
+            params.append(version_option)
+
+        AppGroup.__init__(self, params=params, **extra)
         self.create_app = create_app
 
         if add_default_commands:

--- a/flask_cli/helpers.py
+++ b/flask_cli/helpers.py
@@ -1,0 +1,10 @@
+import os
+try:
+    from flask.helpers import get_debug_flag
+except ImportError:
+
+    def get_debug_flag(default=None):
+        val = os.environ.get('FLASK_DEBUG')
+        if not val:
+            return default
+        return val not in ('0', 'false', 'no')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,7 +17,7 @@ from click.testing import CliRunner
 from flask import Flask, current_app
 
 from flask_cli.cli import AppGroup, FlaskGroup, NoAppException, ScriptInfo, \
-    find_best_app, locate_app, script_info_option, with_appcontext
+    find_best_app, locate_app, with_appcontext
 from flask_cli.ext import FlaskCLI
 
 
@@ -123,7 +123,6 @@ def test_flaskgroup():
         return Flask("flaskgroup")
 
     @click.group(cls=FlaskGroup, create_app=create_app)
-    @script_info_option('--config', script_info_key='config')
     def cli(**params):
         pass
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,7 +17,7 @@ from click.testing import CliRunner
 from flask import Flask, current_app
 
 from flask_cli.cli import AppGroup, FlaskGroup, NoAppException, ScriptInfo, \
-    find_best_app, locate_app, with_appcontext
+    find_best_app, locate_app, with_appcontext, prepare_exec_for_file
 from flask_cli.ext import FlaskCLI
 
 
@@ -47,6 +47,14 @@ def test_find_best_app():
         myapp2 = Flask('appname2')
 
     pytest.raises(NoAppException, find_best_app, mod)
+
+
+def test_prepare_exec_for_file():
+    """Test of prepare_exec_for_file."""
+    assert prepare_exec_for_file('test.py') == 'test'
+    assert prepare_exec_for_file('/usr/share/__init__.py') == 'share'
+    with pytest.raises(NoAppException):
+        prepare_exec_for_file('test.txt')
 
 
 def test_locate_app():

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@
 # the terms of the Revised BSD License; see LICENSE file for more details.
 
 [tox]
-envlist = {py26,py27,py33,py34}-{lowest,latest,devel}
+envlist = {py27,py33,py34,py35}-{lowest,latest,devel}
 
 [testenv]
 commands =


### PR DESCRIPTION
This backports:
- https://github.com/pallets/flask/commit/523e27118359425048541d92892f20ee048c0b76
- https://github.com/pallets/flask/commit/a7d829c61854bc609a343eec114d2a129761fe9f
- https://github.com/pallets/flask/commit/9594876c1f6377a3f8b911d31e8c941295baa281
- https://github.com/pallets/flask/commit/a72583652329da810fc2a04e8541a0e2efd47ee1
- https://github.com/pallets/flask/commit/6bee3e4995066466a35ac080844d4962a728d084
- https://github.com/pallets/flask/commit/6b28ceba83c3b76eea2e5a89327318af67404298
- https://github.com/pallets/flask/commit/fe5f714026b68b1416c3d3985bce5063901c320f

It also removes Python 2.6 from the Tox config and adds Python 3.5.
